### PR TITLE
Move encode/decode to a separate file

### DIFF
--- a/messenger/codec.go
+++ b/messenger/codec.go
@@ -1,0 +1,17 @@
+package messenger
+
+import (
+	"bytes"
+	"github.com/ugorji/go/codec"
+)
+
+var ch codec.CborHandle
+
+func encode(v interface{}, buf *bytes.Buffer) {
+	codec.NewEncoder(buf, &ch).MustEncode(v)
+}
+
+func decode(buf *bytes.Buffer, v interface{}) {
+	dec := codec.NewDecoder(buf, &ch)
+	dec.MustDecode(v)
+}

--- a/messenger/conn.go
+++ b/messenger/conn.go
@@ -3,7 +3,6 @@ package messenger
 import (
 	"bytes"
 	"fmt"
-	"github.com/ugorji/go/codec"
 	"net"
 )
 
@@ -65,15 +64,4 @@ func putUint32(b []byte, v uint32) {
 	b[1] = byte(v >> 8)
 	b[2] = byte(v >> 16)
 	b[3] = byte(v >> 24)
-}
-
-var ch codec.CborHandle
-
-func encode(v interface{}, buf *bytes.Buffer) {
-	codec.NewEncoder(buf, &ch).MustEncode(v)
-}
-
-func decode(buf *bytes.Buffer, v interface{}) {
-	dec := codec.NewDecoder(buf, &ch)
-	dec.MustDecode(v)
 }

--- a/messenger/messenger.go
+++ b/messenger/messenger.go
@@ -732,7 +732,7 @@ func (s peerState) String() string {
 
 func (msg *message) String() string {
 	if msg == nil {
-		return "[message: nil]"
+		return "[message: <nil>]"
 	}
 	if msg.Body != nil {
 		return fmt.Sprintf("[message[%s/%s]: topic: %s; body.len: %d]", msg.MessageId, msg.MessageType, msg.Topic, len(msg.Body))


### PR DESCRIPTION
It's used all over the place in the messenger.

It's also the only dependency outside of the stdlib, pretty sweet!